### PR TITLE
Update Fallback action so it works with API only

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,14 +201,20 @@ sending them to a special `FallbackController` with an `index` action:
 
 ```rb
 # app/controllers/fallback_controller.rb
-class FallbackController < ActionController::Base
+class FallbackController < ApplicationController
+  include ActionController::MimeResponds
+
   def index
-    render file: 'public/index.html'
+    respond_to do |format|
+      format.html { render body: Rails.root.join('public/index.html').read }
+    end
   end
 end
 ```
 
-This action has just one job: to render the HTML file for our React application!
+This action has just one job: to render the contents of the `index.html` file 
+from our built React application! We need the `respond_to` block because our
+Rails application in API only mode won't render HTML responses by default.
 
 Experiment with the code above. Run `rails s` to run the application. Try
 commenting out the last line of the `routes.rb` file, and visit


### PR DESCRIPTION
Hey @ihollander! I was putting together my lecture for deployment this phase and noticed that the fallback route wasn't actually rendering the react application. I took a cue from [this post on stack overflow](https://stackoverflow.com/questions/48140063/rails-not-rendering-public-index-html-file-blank-page-in-browser) and updated the controller and now I'm actually able to refresh the page and see the react app as a response from the fallback route.

In particular, the bug shows up when you're on a client side route and refresh the page. I was getting an empty screen and none of the react code. After adding this to the FallbackController, I was able to get the app working after a refresh.